### PR TITLE
Remove cuttings

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1001,11 +1001,6 @@ links:
     url: "http://lexicon.ft.com/?ft_site=falcon"
     submenu:
 
-  - &presscuttings
-    label: "Press Cuttings"
-    url: "http://presscuttings.ft.com/presscuttings/search.htm"
-    submenu:
-
   - &economic_calendar
     label: "Economic Calendar"
     url: "https://markets.ft.com/data/world/economic-calendar"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -398,8 +398,6 @@ footer:
         submenu:
       - <<: *currency_converter
         submenu:
-      - <<: *presscuttings
-        submenu:
 
 
 navbar-simple:


### PR DESCRIPTION
The Press Cuttings tool has now been removed. This link should be removed from the footer.