### PR TITLE
Build the list of links and save to S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,8 @@ ifndef AWS_SECRET_KEY
 endif
 	@s3-cli put ./build/navigation.json s3://origami-navigation-service-data-eu/v2/navigation.json --region eu-west-1 -P
 	@s3-cli put ./build/navigation.json s3://origami-navigation-service-data-us/v2/navigation.json --region us-east-1 -P
+	@s3-cli put ./build/links.json s3://origami-navigation-service-data-eu/v2/links.json --region eu-west-1 -P
+	@s3-cli put ./build/links.json s3://origami-navigation-service-data-us/v2/links.json --region us-east-1 -P
 	@$(DONE)
 
 update-cmdb:

--- a/src/build.js
+++ b/src/build.js
@@ -4,6 +4,7 @@ const removeTrailingSpaces = require('./utilities/removeWhitespaceFromEndOfLines
 const readAndConcatFiles = require('./utilities/readAndConcatFiles');
 const removeLinksFromObject = require('./utilities/removeLinksFromObj');
 const yamlToJSON = require('./utilities/yamlToJSON');
+const saveLinksToFile = require('./utilities/saveLinksToFile');
 const saveToFile = require('./utilities/saveToFile');
 
 module.exports = function (files) {
@@ -11,6 +12,7 @@ module.exports = function (files) {
 		.then(readAndConcatFiles)
 		.then(removeTrailingSpaces)
 		.then(yamlToJSON)
+		.then(saveLinksToFile)
 		.then(removeLinksFromObject)
 		.then(saveToFile);
 };

--- a/src/utilities/saveLinksToFile.js
+++ b/src/utilities/saveLinksToFile.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const directoryExists = require('./directoryExists');
+const createDirectory = require('./createDirectory');
+
+module.exports = function saveToFile(data) {
+	const destDir = path.resolve(__dirname, '../../', 'build');
+
+	if (!directoryExists(destDir)) {
+		createDirectory(destDir);
+	}
+
+	fs.writeFileSync(path.join(destDir, 'links.json'), JSON.stringify(data.links, null, 4), {
+		encoding: 'utf8'
+	});
+	return data;
+};

--- a/test/integration/validation.test.js
+++ b/test/integration/validation.test.js
@@ -7,14 +7,13 @@ const path = require('path');
 const throat = require('throat')(10);
 const heads = require('heads');
 const url = require('url');
+const schema = require('../../data/schema');
 
 
 describe('Navigation data', () => {
-	let schema;
 	let navigationData;
 
 	beforeEach(() => {
-		schema = require('../../data/schema');
 		navigationData = require('../../build/navigation');
 	});
 
@@ -43,4 +42,21 @@ describe('Navigation data', () => {
 			});
 		});
 	});
+});
+
+describe('Links data', () => {
+	let linksData;
+
+	beforeEach(() => {
+		linksData = require('../../build/links');
+	});
+
+	it('adheres to navigation schema', () => {
+		linksData.forEach(link => {
+			const valid = schema.validate('item', link);
+			assert.isNull(schema.errors, 'The navigation data did not match the scheme:' + JSON.stringify(schema.errors, null, 4));
+			assert.equal(valid, true, 'The navigation data did not match the scheme');
+		});
+	});
+
 });


### PR DESCRIPTION
This builds the full list of links and uploads to S3 under `/v2/links.json`. Once this is merged I can work on exposing this in the navigation service itself.

The `links.json` file looks like this:

```js
[
    {
        "label": String,
        "url": String,
        "disableTracking": (Boolean || undefined),
        "submenu": null
    }
    // ...
]
```

@i-like-robots: does this look like it'll suit your needs?