### PR TITLE
Add segment IDs to subscribe links

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1036,6 +1036,16 @@ links:
     url: "/logout"
     submenu:
 
+  - &anon_subscribe
+    label: "Subscribe"
+    url: "/products?segmentId=d290332b-e8e8-d29b-2ff4-2019b13f008a"
+    submenu:
+  
+  - &header_subscribe
+    label: "Subscribe"
+    url: "/products?segmentId=f860e6c2-18af-ab30-cd5e-6e3a456f9265"
+    submenu:
+  
   - &subscribe
     label: "Subscribe"
     url: "/products"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -332,7 +332,7 @@ anon:
   label: Anon
   items:
   - <<: *help
-  - <<: *subscribe
+  - <<: *anon_subscribe
   - <<: *sign_in
 
 
@@ -420,7 +420,7 @@ navbar-right-anon:
   label: Navigation
   items:
   - <<: *sign_in
-  - <<: *subscribe
+  - <<: *header_subscribe
 
 
 navbar-uk:


### PR DESCRIPTION
Marketing want to be able to properly attribute where user's are coming from and to assign the correct segment ID to those particular users. Its currently difficult to assign users to the correct segment IDs when the incoming links don't have any unique attributes assigned