### PR TITLE
Product is meant to be "origami services and node modules"

### DIFF
--- a/whitesource.config.json
+++ b/whitesource.config.json
@@ -1,7 +1,7 @@
 {
 	"checkPolicies": true,
 	"projectName": "origami-navigation-data",
-	"productName": "origami-navigation-data",
+	"productName": "origami services and node modules",
 	"devDep": false,
 	"failOnError": true
 }


### PR DESCRIPTION
This is to have all our projects controllable via one whitesource product. No need to duplicate policies everywhere.