### PR TITLE
Fix the tests

### DIFF
--- a/test/integration/validation.test.js
+++ b/test/integration/validation.test.js
@@ -31,7 +31,11 @@ describe('Navigation data', () => {
 			)
 		);
 
-		const urls = linkYaml.links.map(link => url.resolve('https://www.ft.com', link.url));
+		const urls = linkYaml.links
+			// Replace "currentPath" with an example path, as this will now error otherwise
+			.map(link => link.url.replace('${currentPath}', '/'))
+			// Resolve the link URL against FT.com
+			.map(linkUrl => url.resolve('https://www.ft.com', linkUrl));
 
 
 		urls.map(url => {


### PR DESCRIPTION
The login link now requires a valid path in the location parameter. If
you send the string "${currentPath}" then it will error with a 403. I've
resolved this by replacing "${currentPath}" in the tests with a valid
path - the home page.