### PR TITLE
Allow release logs to fail

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,6 @@ deployment:
     branch: master
     commands:
       - make deploy-s3
-      - make release-log
+      - make release-log || true
       - make update-cmdb
       - make auto-version


### PR DESCRIPTION
They have been for a while it seems. I'm going to fix, but for now
really want to get the auto-versioning in place