### PR TITLE
delete analysts research link

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1181,11 +1181,6 @@ links:
     url: "http://www.businessesforsale.com/ft2/notices"
     submenu:
 
-  - &analyst_research
-    label: "Analysts Research"
-    url: "http://commerce.uk.reuters.com/purchase/mostPopular.do?rpc=471"
-    submenu:
-
   - &executive_job_search
     label: "Executive Job Search"
     url: "https://www.exec-appointments.com/"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -357,7 +357,6 @@ footer:
       - <<: *group_subscriptions
       - <<: *republishing
       - <<: *contracts_tenders
-      - <<: *analyst_research
       - <<: *executive_job_search
       - <<: *advertise_with_the_ft
       - <<: *ft_twitter


### PR DESCRIPTION
This PR is related to this next ops cops ticket.
https://trello.com/c/Gs605GRw/357-broken-link-in-the-footer

The Analysts Research link is not working anymore.
We are going to delete the link.