### PR TITLE
Move How To Spend It under the Life & Arts sub-menu

### DIFF
--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -234,6 +234,7 @@ drawer-uk:
               - <<: *cycling_tours
               - <<: *city_breaks
               - <<: *winter_breaks
+          - <<: *how_to_spend_it
       - <<: *personal_finance
         submenu: &personal_finance_submenu
           label:
@@ -435,7 +436,6 @@ navbar-uk:
     submenu: *work_careers_submenu
   - <<: *life_arts
     submenu: *life_arts_submenu
-  - <<: *how_to_spend_it
 
 navbar-international:
   label: Navigation
@@ -456,4 +456,3 @@ navbar-international:
     submenu: *work_careers_submenu
   - <<: *life_arts
     submenu: *life_arts_submenu
-  - <<: *how_to_spend_it


### PR DESCRIPTION
There isn't enough room to have it on the main navigation without breaking the layout.

Adding this and Tech has caused overlaps, which we've already tried to fix.

There's also Graphics which wants to get on the main nav too, which won't fit at the moment.

FT.com ops-cops issue is https://trello.com/c/Yj2RqzME/492-navigation-items-overlap-at-the-medium-breakpoint.

Slack thread is at https://financialtimes.slack.com/archives/C042NBBTM/p1542026115376800.

I've also messaged JK about getting approval for this change.