### PR TITLE
Revert "Add the Careers page to the footer navigation"

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1385,8 +1385,3 @@ links:
     label: "Slavery Statement & Policies"
     url: "https://help.ft.com/help/legal/slavery-statement/"
     submenu:
-
-  - &about_us_careers
-    label: "Careers"
-    url: "https://aboutus.ft.com/en-gb/careers/"
-    submenu:

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -344,7 +344,6 @@ footer:
       - <<: *about_us
       - <<: *accessibility
       - <<: *myft_tour
-      - <<: *about_us_careers
   - label: Legal & Privacy
     url:
     submenu:


### PR DESCRIPTION
Reverts Financial-Times/origami-navigation-data#152 – this change seems to have broken the footer:

<img width="1439" alt="Screenshot 2019-04-29 at 15 07 48" src="https://user-images.githubusercontent.com/138944/56901671-9807e580-6a90-11e9-9796-d3600e022d33.png">
