### PR TITLE
Add the Careers page to the footer navigation

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1385,3 +1385,8 @@ links:
     label: "Slavery Statement & Policies"
     url: "https://help.ft.com/help/legal/slavery-statement/"
     submenu:
+
+  - &about_us_careers
+    label: "Careers"
+    url: "https://aboutus.ft.com/en-gb/careers/"
+    submenu:

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -344,6 +344,7 @@ footer:
       - <<: *about_us
       - <<: *accessibility
       - <<: *myft_tour
+      - <<: *about_us_careers
   - label: Legal & Privacy
     url:
     submenu:


### PR DESCRIPTION
This was requested by Cherry Ainsworth. The change has been approved
by Anna Shipman, James Webb, and Christine Ng.

Reopening this now that the next navigation API has a higher threshold
for splitting sections (https://github.com/Financial-Times/next-navigation-api/pull/43)