### PR TITLE
Remove link in footer to Economic Calendar

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1066,11 +1066,6 @@ links:
     url: "/newsletters"
     submenu:
 
-  - &economic_calendar
-    label: "Economic Calendar"
-    url: "https://markets.ft.com/data/world/economic-calendar"
-    submenu:
-
   - &lunch_with_the_ft
     label: "Lunch with the FT"
     url: "/lunch-with-the-ft"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -387,8 +387,6 @@ footer:
         submenu:
       - <<: *enterprise_tools
         submenu:
-      - <<: *economic_calendar
-        submenu:
       - <<: *newsfeed
         submenu:
       - <<: *newsletters


### PR DESCRIPTION
The economic calendar tool has been removed from Markets Data so the link needs to be removed from the footer.