### PR TITLE
Relabel and redirect Account Settings

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1172,8 +1172,8 @@ links:
     submenu:
 
   - &my_account
-    label: "Account Settings"
-    url: "https://myaccount.ft.com/details/core/view"
+    label: "Settings & Account"
+    url: "https://www.ft.com/myaccount"
     submenu:
 
   - &contact_preferences


### PR DESCRIPTION
 - Relabel "Account Settings" as "Settings and Accounts" to be more consistent with mobile app terminology (related JIRA ticket: [AC-210](https://financialtimes.atlassian.net/browse/AC-210)).
 - Redirect old account settings page to new Manage My Account page (related JIRA ticket: [AC-189](https://financialtimes.atlassian.net/browse/AC-189)).

~Please note, this is labeled as "DO NOT MERGE," as we need to double check that hardcoding the new URLs won't affect any analytics. We also need to edit other instances of "Account Settings" and deploy them simultaneously.~