### PR TITLE
remove fastft from navbar-simple

### DIFF
--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -421,7 +421,6 @@ navbar-simple:
   label: Navigation
   items:
   - <<: *home
-  - <<: *fastft
   - <<: *markets_data
 
 


### PR DESCRIPTION
we would like to remove fastft from mobile nav on ft.com front-page