### PR TITLE
Replace Exchange Traded Funds with ETF Hub

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -549,11 +549,6 @@ links:
   - &ftfm
     label: "FTfm"
     url: "/ftfm"
-    submenu:    
-
-  - &exchange_traded_funds
-    label: "Exchange Traded Funds"
-    url: "/ftfm/etfs"
     submenu:
 
   - &investment_strategy

--- a/data/links.yaml
+++ b/data/links.yaml
@@ -476,6 +476,11 @@ links:
     url: "https://markets.ft.com/data"
     submenu:
 
+  - &etf_hub
+    label: "ETF Hub"
+    url: "https://etf.ft.com"
+    submenu:
+
   - &commodities
     label: "Commodities"
     url: "/commodities"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -150,7 +150,7 @@ drawer-uk:
               label:
               items:
               - <<: *ftfm
-              - <<: *exchange_traded_funds
+              - <<: *etf_hub
               - <<: *funds_regulation
               - <<: *pensions_industry
           - <<: *trading


### PR DESCRIPTION
The ETF Hub is being developed by TrackInsights, a third-party.

The Biz Ops product that represents this site is https://biz-ops.in.ft.com/Product/etf-investing.

And the DNS entry was created in https://github.com/Financial-Times/dns/pull/228.

### Todo

- [x] Agree on the position within the Markets submenu

### Preview

![image](https://user-images.githubusercontent.com/51677/84267443-fb7e9680-ab1d-11ea-9bf0-c5202966374a.png)



