### PR TITLE
chore: update privacy link label (ACC-107)

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1217,7 +1217,7 @@ links:
     submenu:
 
   - &privacy
-    label: "Privacy"
+    label: "Privacy Policy"
     url: "http://help.ft.com/help/legal-privacy/privacy/"
     submenu:
 


### PR DESCRIPTION
Updates the privacy link in the footer from `Privacy` to `Privacy Policy`.

https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1108&projectKey=ACC&modal=detail&selectedIssue=ACC-107