### PR TITLE
ADSDEV-540 Temporarily update Privacy link text

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1217,7 +1217,7 @@ links:
     submenu:
 
   - &privacy
-    label: "Privacy Policy"
+    label: "Privacy - CCPA UPDATES"
     url: "http://help.ft.com/help/legal-privacy/privacy/"
     submenu:
 


### PR DESCRIPTION
To comply with the new CCPA legislation we need to change the Privacy link in the footer to reflect that there are some updates to the Privacy Policy. This only needs to be show until 1st of August 2020 and we will revert on that date.