### PR TITLE
Removing the CCPA notification; see PR #issue-444804510 on this repo

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1217,7 +1217,7 @@ links:
     submenu:
 
   - &privacy
-    label: "Privacy - CCPA UPDATES"
+    label: "Privacy Policy"
     url: "http://help.ft.com/help/legal-privacy/privacy/"
     submenu:
 


### PR DESCRIPTION
See: https://github.com/Financial-Times/origami-navigation-data/pull/257#issue-444804510

In July the Compliance team asked that we update the privacy policy link so that it contained the text 'CCPA Updates' - this was a temporary change and should now be reverted back to "Privacy Policy".

This PR reverts the text.