### PR TITLE
Use the new $default-branch macro instead of hardcoding the branch name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - $default-branch
 
 jobs:
   deploy:


### PR DESCRIPTION
This will help with any future wok on renaming the default branch name.