### PR TITLE
Move ETF Hub under Markets submenu

### DIFF
--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -150,7 +150,6 @@ drawer-uk:
               label:
               items:
               - <<: *ftfm
-              - <<: *etf_hub
               - <<: *funds_regulation
               - <<: *pensions_industry
           - <<: *trading
@@ -163,6 +162,7 @@ drawer-uk:
               - <<: *otc_markets
               - <<: *derivatives
           - <<: *moral_money
+          - <<: *etf_hub
       - <<: *graphics
       - <<: *opinion
         submenu: &opinion_submenu


### PR DESCRIPTION
The request from Dan:

> There's been a bit of discussion about the location of the ETF Hub, and to help with increasing traffic to the Hub, and also commercial requirements they want to bring the ETF Hub to the Markets Section Navigation
> 
> Essentially, we are just bring the ETF Hub up one level of navigation.
> 
> So ETF Hub should sit in Markets, probably next to Moral Money.
> 
> Leaving Fund Management only with 3 subs streams.

Added after Moral Money under the Markets submenu.

![Screenshot 2020-09-14 at 14 36 56](https://user-images.githubusercontent.com/51677/93092949-03f3e980-f698-11ea-92b7-cd0b01098009.png)

Also appears on the hover display for the Markets submenu.

![Screenshot 2020-09-14 at 14 36 59](https://user-images.githubusercontent.com/51677/93092954-05251680-f698-11ea-9f47-7e8f09fcd2af.png)

Removed from the Fund Management submenu.

![Screenshot 2020-09-14 at 14 37 20](https://user-images.githubusercontent.com/51677/93092958-05bdad00-f698-11ea-8ae7-e38fa79a1aad.png)
