### PR TITLE
remove graphics link from top level navigation

### DIFF
--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -319,7 +319,6 @@ drawer-international:
       - <<: *markets
         submenu: *markets_submenu
       - <<: *climate_capital
-      - <<: *graphics
       - <<: *opinion
         submenu: *opinion_submenu
       - <<: *life_arts
@@ -451,7 +450,6 @@ navbar-uk:
   - <<: *markets
     submenu: *markets_submenu
   - <<: *climate_capital
-  - <<: *graphics
   - <<: *opinion
     submenu: *opinion_submenu
   - <<: *life_arts
@@ -472,7 +470,6 @@ navbar-international:
   - <<: *markets
     submenu: *markets_submenu
   - <<: *climate_capital
-  - <<: *graphics
   - <<: *opinion
     submenu: *opinion_submenu
   - <<: *life_arts


### PR DESCRIPTION
This removes graphics from the top level navigation for uk and international users. This resolves the issue reported in https://financialtimes.slack.com/archives/C02MECVF6/p1607440865202600?thread_ts=1607437799.201100&cid=C02MECVF6