### PR TITLE
ACC-764 add Contact Us to footer

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1206,6 +1206,11 @@ links:
     url: "http://help.ft.com"
     submenu:
 
+  - &contact_us
+    label: "Contact Us"
+    url: "https://aboutus.ft.com/en-gb/contact-us/"
+    submenu:
+
   - &about_us
     label: "About Us"
     url: "http://www.ft.com/aboutus"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -364,6 +364,7 @@ footer:
       items:
       - <<: *view_site_tips
       - <<: *help
+      - <<: *contact_us
       - <<: *about_us
       - <<: *accessibility
       - <<: *myft_tour


### PR DESCRIPTION
Customers have been complaining that they are finding it difficult to find ways to contact the FT support. Adam Winning requested that an explicit "Contact Us" link is added to the footer, just under the "Help Centre" link. 

[Link to Jira ticket](https://financialtimes.atlassian.net/browse/ACC-764)