### PR TITLE
Revert "ACC-764 add Contact Us to footer"

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1206,11 +1206,6 @@ links:
     url: "http://help.ft.com"
     submenu:
 
-  - &contact_us
-    label: "Contact Us"
-    url: "https://aboutus.ft.com/en-gb/contact-us/"
-    submenu:
-
   - &about_us
     label: "About Us"
     url: "http://www.ft.com/aboutus"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -364,7 +364,6 @@ footer:
       items:
       - <<: *view_site_tips
       - <<: *help
-      - <<: *contact_us
       - <<: *about_us
       - <<: *accessibility
       - <<: *myft_tour


### PR DESCRIPTION
Reverts Financial-Times/origami-navigation-data#315

The column starts breaking at 7, so we need to figure out where to change 6 to 7 before adding "Contact us". 

![Screenshot 2020-12-09 at 15 45 13](https://user-images.githubusercontent.com/31079643/101652490-33678780-3a36-11eb-9225-d11b6a88399f.png)
