### PR TITLE
ACC-764 Revert "Revert "ACC-764 add Contact Us to footer""

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1206,6 +1206,11 @@ links:
     url: "http://help.ft.com"
     submenu:
 
+  - &contact_us
+    label: "Contact Us"
+    url: "https://aboutus.ft.com/en-gb/contact-us/"
+    submenu:
+
   - &about_us
     label: "About Us"
     url: "http://www.ft.com/aboutus"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -364,6 +364,7 @@ footer:
       items:
       - <<: *view_site_tips
       - <<: *help
+      - <<: *contact_us
       - <<: *about_us
       - <<: *accessibility
       - <<: *myft_tour


### PR DESCRIPTION
We fixed the underlying issue with https://github.com/Financial-Times/next-navigation-api/pull/63, so we are good to display the Contact Us. 

(Reverts Financial-Times/origami-navigation-data#316)