### PR TITLE
Change FT Transact url

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1303,7 +1303,7 @@ links:
 
   - &ft_transact
     label: "FT Transact"
-    url: "https://transact.ft.com/en-gb/"
+    url: "https://transact.ft.com/"
     submenu:
 
   - &secondary_schools


### PR DESCRIPTION
By this change (https://github.com/Financial-Times/dns/pull/988), the url with `/en-gb/` doesn't work anymore.
Therefore we are going to remove `/en-gb/`.

[Jira ticket](https://financialtimes.atlassian.net/browse/NOPS-605)