### PR TITLE
Update the url for Editorial code

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1248,7 +1248,7 @@ links:
 
   - &editorial_code
     label: "FT Editorial Code of Practice"
-    url: "http://aboutus.ft.com/en-gb/ft-editorial-code/"
+    url: "http://aboutus.ft.com/company/our-standards/editorial-code"
     submenu:
 
   - &conferences_events


### PR DESCRIPTION
We need to update the url for Editorial code because a new version of the About Us site has been released