### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,14 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # Origami Navigation Service Data
 
 Provides the data consumed via origami-navigation-service
+
+## Code
+
+origami-navigation-service-data
 
 ## Service Tier
 
@@ -20,29 +28,19 @@ Fastly
 
 ## Contains Personal Data
 
-no
+No
 
 ## Contains Sensitive Data
 
-no
+No
 
-## Delivered By
+## Can Download Personal Data
 
-origami-team
+No
 
-## Supported By
+## Can Contact Individuals
 
-origami-team
-
-## Known About By
-
-* lee.moody
-* jake.champion
-* rowan.manning
-
-## Dependencies
-
-* ft-fastly
+No
 
 ## Failover Architecture Type
 
@@ -78,25 +76,32 @@ The navigation data lives as YAML in the service's GitHub repository. Data is mo
 
 ## More Information
 
-https://github.com/Financial-Times/origami-navigation-data
+<https://github.com/Financial-Times/origami-navigation-data>
 
 ## First Line Troubleshooting
 
 There are a few things you can try before contacting the Origami team:
 
-1. Check that the navigation data is accessible via the web, [this URL](https://origami-navigation-data.in.ft.com/v2/links.json) should return a `200` response
+1.  Check that the navigation data is accessible via the web, [this URL](https://origami-navigation-data.in.ft.com/v2/links.json) should return a `200` response
 
 ## Second Line Troubleshooting
 
 If the application is failing entirely, you'll need to check a couple of things:
 
-1. Did a deployment just happen (a commit on `master`)? If so, roll it back to bring the service back up (hopefully)
-2. Is the CI job which uploads the data running correctly? And is the Fastly key up-to-date?
-
+1.  Did a deployment just happen (a commit on `master`)? If so, roll it back to bring the service back up (hopefully)
+2.  Is the CI job which uploads the data running correctly? And is the Fastly key up-to-date?
 
 ## Monitoring
 
 This service is a Fastly service which has no backend/origin. It doesn't currently have a `__health` endpoint, it would only ever be offline if Fastly or Dyn go offline.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Failover Details
+Enter descriptive text satisfying the following:
+The actions required to fail this system from one region to another. Either provide a set of numbered steps or a link to a detailed process that operations can follow.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Data Recovery Details
 
@@ -110,3 +115,10 @@ This service is released whenever a new commit appears on the `master` branch of
 
 The only key used by this system is an Fastly API key. This key has read/write access to a single Fastly service. We rotate this key manually.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/origami-navigation-data/blob/runbook-no-relationships-2021-03-19/RUNBOOK.md) file has been automatically regenerated from the Biz Ops data for the **origami-navigation-service-data** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **origami-navigation-service-data** system in [Biz Ops](https://biz-ops.in.ft.com/System/origami-navigation-service-data).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
