### PR TITLE
attempt a deployment once a day to check if the api key is valid

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: 0 12 * * * # Runs at 12:00 UTC every day
 
 jobs:
   deploy:


### PR DESCRIPTION
the api keys have an expiry date and sometimes this project goes a long time without a deployment and so we don't realise the api key has expired.

If we run a daily deployment, we will get a notification if the deployment failed (most likely because the api key expired), this should help us become aware that we need to rotate the key, hopefully before any important navigation changes are wanting to be made