### PR TITLE
feat(HIVE-37): Add FT Community to nav drawer

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -120,7 +120,7 @@ links:
     label: "UK General Election"
     url: "/uk-general-election"
     submenu:
-    
+
   - &uk_companies
     label: "UK Companies"
     url: "/companies/uk"
@@ -565,7 +565,7 @@ links:
     label: "Capital Markets"
     url: "/capital-markets"
     submenu:
-    
+
   - &moral_money
     label: "Moral Money"
     url: "/moral-money"
@@ -575,7 +575,7 @@ links:
     label: "Fund Management"
     url: "/fund-management"
     submenu:
-    
+
   - &ftfm
     label: "FTfm"
     url: "/ftfm"
@@ -920,7 +920,7 @@ links:
     label: "Winter Sports"
     url: "/winter-sports"
     submenu:
-    
+
   - &globetrotter
     label: "FT Globetrotter"
     url: "/globetrotter"
@@ -1025,11 +1025,11 @@ links:
     label: "Television"
     url: "/television"
     submenu:
-    
+
   - &climate_capital
     label: "Climate"
     url: "/climate-capital"
-    submenu:    
+    submenu:
 
   - &business_education
     label: "Business Education"
@@ -1205,12 +1205,12 @@ links:
     label: "Subscribe"
     url: "/products?segmentId=d290332b-e8e8-d29b-2ff4-2019b13f008a"
     submenu:
-  
+
   - &header_subscribe
     label: "Subscribe"
     url: "/products?segmentId=f860e6c2-18af-ab30-cd5e-6e3a456f9265"
     submenu:
-  
+
   - &subscribe
     label: "Subscribe"
     url: "/products"
@@ -1255,7 +1255,7 @@ links:
     label: "Accessibility"
     url: "/accessibility"
     submenu:
-  
+
   - &myft_tour
     label: "myFT Tour"
     url: "/tour/myft"
@@ -1284,11 +1284,6 @@ links:
   - &editorial_code
     label: "FT Editorial Code of Practice"
     url: "http://aboutus.ft.com/company/our-standards/editorial-code"
-    submenu:
-
-  - &community_events
-    label: "FT Community"
-    url: "https://www.ft.com/tour/community"
     submenu:
 
   - &conferences_events
@@ -1397,8 +1392,13 @@ links:
     submenu:
 
   - &ft_community
-    <<: *community_events
+    url: "https://www.ft.com/tour/community"
+    submenu:
     label: "FT Community"
+
+  - &ft_community_relative
+    <<: *ft_community
+    url: "/tour/community"
 
   - &ft_live
     <<: *conferences_events

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -261,7 +261,7 @@ drawer-uk:
               - <<: *globetrotternewyorkcity
               - <<: *globetrotterhongkong
               - <<: *globetrottertokyo
-              - <<: *globetrottersingapore  
+              - <<: *globetrottersingapore
       - <<: *personal_finance
         submenu: &personal_finance_submenu
           label:
@@ -292,6 +292,7 @@ drawer-uk:
       - <<: *video
       - <<: *podcasts
       - <<: *newsfeed
+      - <<: *ft_community_relative
   - label:
     url:
     submenu: &extras_submenu


### PR DESCRIPTION
- Adds `FT Community` to the drawer nav with a relative link (like most of the other links in the drawer).