### PR TITLE
Mark the project as  deprecated now that it is not used anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 Origami Navigation Service Data
 ===============================
 
+**Deprecated - The [origami-navigation-service](https://github.com/Financial-Times/origami-navigation-service#how-to-edit-navigation-data) now contains the data itself.**
+
+---
+
 Provides the data consumed via [origami-navigation-service].
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)][license]

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -16,7 +16,7 @@ Platinum
 
 ## Lifecycle Stage
 
-Production
+Deprecated
 
 ## Primary URL
 

--- a/origami.json
+++ b/origami.json
@@ -6,7 +6,7 @@
 		"origami"
 	],
 	"support": "https://github.com/Financial-Times/origami-navigation-data/issues",
-	"supportStatus": "active",
+	"supportStatus": "deprecated",
 	"supportContact": {
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/origami-support"


### PR DESCRIPTION
Origami-navigation-service now contains/owns the data for the navigation itself - this is to simplify our architecture and estate.

we've checked the [logs in splunk](https://financialtimes.splunkcloud.com/en-GB/app/search/search?sid=1628087834.28769071) and can see no requests being made to origami-navigation-data since releasing the new version of the navigation-service into production.

If the link to splunk no longer works, the query we ran was:
```sql
index=restricted_ftdotcom host="origami-navigation-data.in.ft.com"
| spath "response.status_code"
| search "response.status_code"=200
| spath "request.user_agent" 
| search "request.user_agent"!="Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)"
```